### PR TITLE
feat: improve performance using pandas

### DIFF
--- a/test_lib.py
+++ b/test_lib.py
@@ -238,7 +238,10 @@ with CoupledSimulation(
             # TODO: ASK TERE WHAT `DRN` IS
             dataframe_with_recharges["drn_cond"].fillna(0, inplace=True)
             mask = dataframe_with_recharges["ibound"] != -1
-            dataframe_with_recharges.loc[mask, "DRN_rate"] = dataframe_with_recharges["delta_H"] * dataframe_with_recharges["drn_cond"]
+            dataframe_with_recharges.loc[mask, "DRN_rate"] = (
+                dataframe_with_recharges["delta_H"]
+                * dataframe_with_recharges["drn_cond"]
+            )
 
             # INFLOW RATES IN SU AND JUNCTIONS
 


### PR DESCRIPTION
# Description

This PR improves the performance of the recharge calculation by changing a for loop iteration for [NumPy](https://numpy.org/) functions.

It decreases the execution time of the example case Llanquihue from 4 hours to around 7 min.